### PR TITLE
Refactor header parsing

### DIFF
--- a/request_parser.py
+++ b/request_parser.py
@@ -1,3 +1,6 @@
+import logging
+
+
 class RequestParser:
     """Deals with parsing requests"""
 
@@ -13,27 +16,52 @@ class RequestParser:
         """Parse the request and store the relevant information"""
         try:
             request_lines = request.strip().splitlines()
+        except Exception as e:
+            logging.error(f"Error processing request: {e}")
+            return
 
-            self.REQUEST_METHOD = request_lines[0].split(' ')[0]
-            self.REQUEST_PATH = request_lines[0].split(' ')[1]
-            self.REQUEST_FILE = self.REQUEST_PATH.split('/')[-1].split('?')[0]
-            self.REQUEST_HOST = request_lines[1].split(':')[1]
-            try:
-                # Check if the port is present
-                self.REQUEST_PORT = request_lines[1].split(':')[2]
-            except IndexError:
-                # Implied port
-                self.REQUEST_PORT = 80
+        if not request_lines:
+            logging.info("Empty request received")
+            return
 
-            self.REQUEST_HEADERS = {}
-            for header in request_lines[2:]:
-                key, value = header.split(": ", 1)
+        first_line = request_lines[0].split()
+        if len(first_line) < 3:
+            logging.info("Malformed request line")
+            return
+
+        self.REQUEST_METHOD = first_line[0]
+        self.REQUEST_PATH = first_line[1]
+        self.REQUEST_FILE = self.REQUEST_PATH.split('/')[-1].split('?')[0]
+
+        self.REQUEST_HEADERS = {}
+        host_value = None
+        for header in request_lines[1:]:
+            if not header:
+                continue
+            if ':' not in header:
+                logging.info(f"Malformed header line: {header}")
+                continue
+            key, value = header.split(':', 1)
+            value = value.lstrip()
+            if key.lower() == 'host':
+                host_value = value
+            else:
                 self.REQUEST_HEADERS[key] = value
-        except:
-            raise ValueError("Unable to parse request")
+
+        if host_value is not None:
+            if ':' in host_value:
+                host, port = host_value.split(':', 1)
+                self.REQUEST_HOST = host.strip()
+                self.REQUEST_PORT = port.strip()
+            else:
+                self.REQUEST_HOST = host_value.strip()
+                self.REQUEST_PORT = 80
+        else:
+            logging.info("Host header missing")
+            self.REQUEST_PORT = 80
 
     @staticmethod
-    def parse_value_by_sep(value: str, include_key: False, key_separator='=', value_separator=',') -> list | dict | str:
+    def parse_value_by_sep(value: str, include_key: bool = False, key_separator='=', value_separator=',') -> list | dict | str:
         """Parse a value by a given separator"""
         if include_key:
             if key_separator not in value:

--- a/request_parser.py
+++ b/request_parser.py
@@ -58,6 +58,7 @@ class RequestParser:
                 self.REQUEST_PORT = 80
         else:
             logging.info("Host header missing")
+            self.REQUEST_HOST = None
             self.REQUEST_PORT = 80
 
     @staticmethod

--- a/request_parser.py
+++ b/request_parser.py
@@ -14,11 +14,10 @@ class RequestParser:
 
     def parse_request(self, request: str) -> None:
         """Parse the request and store the relevant information"""
-        try:
-            request_lines = request.strip().splitlines()
-        except Exception as e:
-            logging.error(f"Error processing request: {e}")
+        if not isinstance(request, str):
+            logging.error("Invalid request: Expected a string")
             return
+        request_lines = request.strip().splitlines()
 
         if not request_lines:
             logging.info("Empty request received")

--- a/request_parser.py
+++ b/request_parser.py
@@ -52,7 +52,11 @@ class RequestParser:
             if ':' in host_value:
                 host, port = host_value.split(':', 1)
                 self.REQUEST_HOST = host.strip()
-                self.REQUEST_PORT = int(port.strip())
+                if port.strip().isdigit():
+                    self.REQUEST_PORT = int(port.strip())
+                else:
+                    logging.warning(f"Invalid port value: {port.strip()}. Defaulting to port 80.")
+                    self.REQUEST_PORT = 80
             else:
                 self.REQUEST_HOST = host_value.strip()
                 self.REQUEST_PORT = 80

--- a/request_parser.py
+++ b/request_parser.py
@@ -52,7 +52,7 @@ class RequestParser:
             if ':' in host_value:
                 host, port = host_value.split(':', 1)
                 self.REQUEST_HOST = host.strip()
-                self.REQUEST_PORT = port.strip()
+                self.REQUEST_PORT = int(port.strip())
             else:
                 self.REQUEST_HOST = host_value.strip()
                 self.REQUEST_PORT = 80

--- a/test_request_parser.py
+++ b/test_request_parser.py
@@ -9,8 +9,8 @@ def test_parse_request_valid():
 
 def test_parse_request_invalid():
     request = "invalid request"
-    with pytest.raises(ValueError):
-        http = HTTP(request)
+    http = HTTP(request)
+    assert http.REQUEST_METHOD is None
 
 def test_parse_value_by_sep_no_key():
     value = "a,b,c"
@@ -28,6 +28,26 @@ def test_parse_value_by_sep_no_separator():
     assert result == "abc"
 
 def test_parse_value_by_sep_invalid_key_separator():
-    value = "a:1,b:2" 
+    value = "a:1,b:2"
     with pytest.raises(ValueError):
         RequestParser.parse_value_by_sep(value, True)
+
+
+def test_parse_request_headers_without_space():
+    request = "GET / HTTP/1.1\r\nHost:www.example.com\r\nUser-Agent:Test\r\n\r\n"
+    http = HTTP(request)
+    assert http.REQUEST_HOST == "www.example.com"
+    assert http.REQUEST_PORT == 80
+    assert http.REQUEST_HEADERS["User-Agent"] == "Test"
+
+
+def test_parse_request_headers_with_port_and_space():
+    request = (
+        "GET / HTTP/1.1\r\n"
+        "Host: www.example.com:8080\r\n"
+        "Accept:text/html\r\n\r\n"
+    )
+    http = HTTP(request)
+    assert http.REQUEST_HOST == "www.example.com"
+    assert http.REQUEST_PORT == "8080"
+    assert http.REQUEST_HEADERS["Accept"] == "text/html"

--- a/test_request_parser.py
+++ b/test_request_parser.py
@@ -49,5 +49,5 @@ def test_parse_request_headers_with_port_and_space():
     )
     http = HTTP(request)
     assert http.REQUEST_HOST == "www.example.com"
-    assert http.REQUEST_PORT == "8080"
+    assert http.REQUEST_PORT == 8080
     assert http.REQUEST_HEADERS["Accept"] == "text/html"


### PR DESCRIPTION
## Summary
- log header parsing issues instead of raising
- look for Host header in any position
- ensure malformed requests return without setting fields
- adjust tests for non-exceptional invalid requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801a0000248330a8efcad01ec545f5